### PR TITLE
Ender compatibility - Missing file extension in main property of package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
       "url": "https://github.com/wookiehangover/underscore.Deferred/blob/master/LICENSE-MIT"
     }
   ],
-  "main": "lib/underscore.deferred",
+  "main": "lib/underscore.deferred.js",
   "engines": {
     "node": "*"
   },


### PR DESCRIPTION
Recent versions of ender seem to require an exact file name. This should probably be fixed in ender. But then again one could argue that `main` should actually be a readl file name.
