### PR TITLE
Fixed a bug in `when`-method where an array with only one promise was immediately resolved

### DIFF
--- a/underscore.deferred.js
+++ b/underscore.deferred.js
@@ -383,15 +383,20 @@
       resolveValues = ( _type(subordinate) === 'array' && arguments.length === 1 ) ? subordinate : slice.call( arguments ),
       length = resolveValues.length;
 
-      if ( _type(subordinate) === 'array' && subordinate.length === 1 ) {
-        subordinate = subordinate[ 0 ];
+      // the count of uncompleted subordinates
+      var remaining;
+      
+      if ( _type(subordinate) === 'array' ) {
+          remaining = length;
+          if ( subordinate.length === 1 ) {
+              subordinate = subordinate[ 0 ];
+          }
+      } else {
+          remaining = length !== 1 || ( subordinate && _isFunction( subordinate.promise ) ) ? length : 0;
       }
 
-      // the count of uncompleted subordinates
-      var remaining = length !== 1 || ( subordinate && _isFunction( subordinate.promise ) ) ? length : 0,
-
       // the master Deferred. If resolveValues consist of only a single Deferred, just use that.
-      deferred = remaining === 1 ? subordinate : _d.Deferred(),
+      var deferred = remaining === 1 ? subordinate : _d.Deferred(),
 
       // Update function for both resolve and progress values
       updateFunc = function( i, contexts, values ) {


### PR DESCRIPTION
If `when` was called with only one promise, the resolver was immediately called:

``` javascript
_.when( [ _.Deferred() ] ).then( function () {
    console.log("2");
} );
console.log("1");
```

printed

``` javascript
2
1
```

All tests are running, but I haven't added a test for this bug because I'm not sure where to put it.

Could you please also bump the version and publish it?
